### PR TITLE
increase terminal brightness

### DIFF
--- a/src/variants/omni-owl-minimal_italics.ts
+++ b/src/variants/omni-owl-minimal_italics.ts
@@ -74,7 +74,7 @@ export const omniOwlMinimalItalics: ThemeSchema = {
     'terminal.ansiMagenta': palette.ansi.COLOR5,
     'terminal.ansiCyan': palette.ansi.COLOR6,
     'terminal.ansiWhite': palette.ansi.COLOR7,
-    'terminal.selectionBackground': alpha(palette.other.AlmostComment, 45),
+    'terminal.selectionBackground': alpha(palette.other.AlmostComment, 200),
     'terminalCursor.background': palette.ansi.COLOR0,
     'terminalCursor.foreground': palette.base.FG,
 


### PR DESCRIPTION
love this theme, but the terminal selections were really bothering me 😄 

before:
<img width="564" alt="Screenshot 2024-05-20 at 2 14 02 PM" src="https://github.com/guilhermerodz/omni-owl/assets/16356719/5e3da5c8-a057-461a-ab54-24c094624a52">

after:
<img width="569" alt="Screenshot 2024-05-20 at 2 14 26 PM" src="https://github.com/guilhermerodz/omni-owl/assets/16356719/e61ba222-87ab-4daf-aa41-54a553bebf8a">
